### PR TITLE
Prevent deprecation error.

### DIFF
--- a/src/api-privacy.php
+++ b/src/api-privacy.php
@@ -136,7 +136,7 @@ class ApiPrivacy extends GithubUpdater {
             }
         }
 
-        if ( $this->getSetting( 'strip_wp_version' ) ) {
+        if ( $this->getSetting( 'strip_wp_version' ) && ! empty( $params[ 'user-agent' ] ) ) {
             // remove the version
             $params[ 'user-agent' ] = str_replace( get_bloginfo( 'version' ), 'Private', $params[ 'user-agent' ] ); 
             $wasModified = true;


### PR DESCRIPTION
I was getting the following error:

> str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated

This fixes that.